### PR TITLE
createJSModules is deprecated

### DIFF
--- a/android/src/main/java/com/react_native_signature/RCTSignaturePackage.java
+++ b/android/src/main/java/com/react_native_signature/RCTSignaturePackage.java
@@ -20,7 +20,7 @@ public class RCTSignaturePackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
+    // Deprecated from RN 0.47.0
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
The component doesn't compile in RN 0.47-rc5 - discussion at facebook/react-native#15232