### PR TITLE
fix problem which will make the signature bitmap be black.

### DIFF
--- a/android/src/main/java/com/react_native_signature/RCTSigntureView.java
+++ b/android/src/main/java/com/react_native_signature/RCTSigntureView.java
@@ -200,7 +200,7 @@ public class RCTSigntureView extends ImageView implements View.OnTouchListener {
 
     public Bitmap getSignature() {
         Bitmap signatureBitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(),
-                Bitmap.Config.RGB_565);
+                Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(signatureBitmap);
         this.draw(canvas);
         return signatureBitmap;


### PR DESCRIPTION
when create bitmap with

```
Bitmap.createBitmap(this.getWidth(),this.getHeight(),Bitmap.Config.RGB_565);
```

It will make the png file background  be black.